### PR TITLE
Fix Modal ref forwarding

### DIFF
--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,17 +1,15 @@
-import { useImperativeHandle, useRef } from "react";
+import { forwardRef, useImperativeHandle, useRef } from "react";
 import { createPortal } from "react-dom";
 import Button from "./Button";
 
-function Modal({ children, buttonCaption, ref }) {
+const Modal = forwardRef(function Modal({ children, buttonCaption }, ref) {
   const dialog = useRef();
 
-  useImperativeHandle(ref, () => {
-    return {
-      open() {
-        dialog.current.showModal();
-      },
-    };
-  });
+  useImperativeHandle(ref, () => ({
+    open() {
+      dialog.current.showModal();
+    },
+  }));
 
   return createPortal(
     <dialog
@@ -25,5 +23,6 @@ function Modal({ children, buttonCaption, ref }) {
     </dialog>,
     document.getElementById("modal-root")
   );
-}
+});
+
 export default Modal;


### PR DESCRIPTION
## Summary
- forward Modal refs so parents can open it imperatively

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: couldn't find ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_683ff774513c832e8eb9617026f0a185