### PR TITLE
Add task completion support

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,13 +10,20 @@ function App() {
   // Initialisierung des projectState aus localStorage (falls vorhanden)
   const [projectState, setProjectState] = useState(() => {
     const storedState = localStorage.getItem("projectState");
-    return storedState
-      ? JSON.parse(storedState)
-      : {
-          selectedProjectId: undefined,
-          projects: [],
-          tasks: [],
-        };
+    if (storedState) {
+      const parsed = JSON.parse(storedState);
+      const tasksWithCompletion = (parsed.tasks || []).map((task) =>
+        Object.prototype.hasOwnProperty.call(task, "completed")
+          ? task
+          : { ...task, completed: false }
+      );
+      return { ...parsed, tasks: tasksWithCompletion };
+    }
+    return {
+      selectedProjectId: undefined,
+      projects: [],
+      tasks: [],
+    };
   });
 
   // Dark Mode State (wird im localStorage persistiert)
@@ -50,6 +57,7 @@ function App() {
         text: text,
         projectId: prevState.selectedProjectId,
         id: taskId,
+        completed: false,
       };
 
       return {
@@ -71,6 +79,15 @@ function App() {
       ...prevState,
       tasks: prevState.tasks.map((task) =>
         task.id === id ? { ...task, text: newText } : task
+      ),
+    }));
+  }
+
+  function handleToggleTaskCompletion(id) {
+    setProjectState((prevState) => ({
+      ...prevState,
+      tasks: prevState.tasks.map((task) =>
+        task.id === id ? { ...task, completed: !task.completed } : task
       ),
     }));
   }
@@ -178,6 +195,7 @@ function App() {
       onAddTask={handleAddTask}
       onDeleteTask={handleDeleteTask}
       onEditTask={handleEditTask}
+      onToggleTaskCompletion={handleToggleTaskCompletion}
       tasks={tasksForSelectedProject}
     />
   );

--- a/src/components/SelectedProject.jsx
+++ b/src/components/SelectedProject.jsx
@@ -9,6 +9,7 @@ function SelectedProject({
   onAddTask,
   onDeleteTask,
   onEditTask,
+  onToggleTaskCompletion,
   onRename,
 }) {
   const [showTasks, setShowTasks] = useState(false);
@@ -109,6 +110,7 @@ function SelectedProject({
           onAdd={onAddTask}
           onDelete={onDeleteTask}
           onEdit={onEditTask}
+          onToggleCompletion={onToggleTaskCompletion}
           tasks={tasks}
         />
       </div>

--- a/src/components/Tasks.jsx
+++ b/src/components/Tasks.jsx
@@ -2,10 +2,11 @@ import { useState, useRef } from "react";
 import NewTask from "./NewTask";
 import ConfirmationModal from "./ConfirmationModal";
 
-function Tasks({ tasks, onAdd, onDelete, onEdit }) {
+function Tasks({ tasks, onAdd, onDelete, onEdit, onToggleCompletion }) {
   const [taskToDelete, setTaskToDelete] = useState(null);
   const [editingTaskId, setEditingTaskId] = useState(null);
   const [editedText, setEditedText] = useState("");
+  const [filter, setFilter] = useState("all");
   const confirmModalRef = useRef();
 
   const handleDeleteClick = (task) => {
@@ -26,12 +27,53 @@ function Tasks({ tasks, onAdd, onDelete, onEdit }) {
     }
   };
 
+  const filteredTasks = tasks.filter((task) => {
+    if (filter === "completed") return task.completed;
+    if (filter === "active") return !task.completed;
+    return true;
+  });
+
   return (
     <section>
       <h2 className="text-2xl font-bold text-stone-700 mb-4 dark:text-stone-300">
         Aufgaben
       </h2>
       <NewTask onAdd={onAdd} />
+
+      {tasks.length > 0 && (
+        <div className="flex gap-2 mt-4">
+          <button
+            className={`px-2 py-1 rounded-md ${
+              filter === "all"
+                ? "bg-stone-400 text-white dark:bg-stone-500"
+                : "bg-stone-200 dark:bg-stone-600 text-stone-800 dark:text-stone-200"
+            }`}
+            onClick={() => setFilter("all")}
+          >
+            Alle
+          </button>
+          <button
+            className={`px-2 py-1 rounded-md ${
+              filter === "active"
+                ? "bg-stone-400 text-white dark:bg-stone-500"
+                : "bg-stone-200 dark:bg-stone-600 text-stone-800 dark:text-stone-200"
+            }`}
+            onClick={() => setFilter("active")}
+          >
+            Offen
+          </button>
+          <button
+            className={`px-2 py-1 rounded-md ${
+              filter === "completed"
+                ? "bg-stone-400 text-white dark:bg-stone-500"
+                : "bg-stone-200 dark:bg-stone-600 text-stone-800 dark:text-stone-200"
+            }`}
+            onClick={() => setFilter("completed")}
+          >
+            Erledigt
+          </button>
+        </div>
+      )}
 
       {tasks.length === 0 && (
         <p className="text-stone-800 my-4 dark:text-stone-200">
@@ -40,7 +82,7 @@ function Tasks({ tasks, onAdd, onDelete, onEdit }) {
       )}
       {tasks.length > 0 && (
         <ul className="p-4 mt-8 rounded-md bg-stone-100 dark:bg-stone-700">
-          {tasks.map((task) => {
+          {filteredTasks.map((task) => {
             const isEditing = editingTaskId === task.id;
             return (
               <li key={task.id} className="flex justify-between items-center my-4">
@@ -69,7 +111,18 @@ function Tasks({ tasks, onAdd, onDelete, onEdit }) {
                   </>
                 ) : (
                   <>
-                    <span className="dark:text-stone-200">{task.text}</span>
+                    <div className="flex items-center gap-2">
+                      <input
+                        type="checkbox"
+                        checked={task.completed}
+                        onChange={() => onToggleCompletion(task.id)}
+                      />
+                      <span
+                        className={`dark:text-stone-200 ${task.completed ? "line-through text-stone-400 dark:text-stone-400" : ""}`}
+                      >
+                        {task.text}
+                      </span>
+                    </div>
                     <div className="flex gap-2">
                       <button
                         className="px-2 py-1 bg-stone-500 rounded-md text-stone-100 hover:bg-stone-600 dark:bg-stone-400 dark:text-stone-900"


### PR DESCRIPTION
## Summary
- preserve task completion state when loading project data
- support task completion toggle
- add filtering by completion status
- show checkboxes in task list

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_683ff91765d0832eb501c079d867ec47