### PR TITLE
Implement reminder notifications

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,10 @@ import NoProjectSelected from "./components/NoProjectSelected";
 import SelectedProject from "./components/SelectedProject";
 import CalendarImportModal from "./components/CalendarImportModal";
 import { importToCalendar } from "./utils/calendarUtils";
+import {
+  requestNotificationPermission,
+  checkDueReminders,
+} from "./utils/notificationUtils";
 
 function App() {
   // Initialisierung des projectState aus localStorage (falls vorhanden)
@@ -45,6 +49,16 @@ function App() {
   useEffect(() => {
     localStorage.setItem("projectState", JSON.stringify(projectState));
   }, [projectState]);
+
+  // Erinnerungen für Projekte, die bald fällig sind
+  useEffect(() => {
+    requestNotificationPermission();
+    checkDueReminders(projectState.projects);
+    const interval = setInterval(() => {
+      checkDueReminders(projectState.projects);
+    }, 60 * 60 * 1000); // stündliche Prüfung
+    return () => clearInterval(interval);
+  }, [projectState.projects]);
 
   // State für das zuletzt erstellte Projekt, das evtl. in den Kalender importiert werden soll
   const [calendarProject, setCalendarProject] = useState(null);

--- a/src/utils/notificationUtils.js
+++ b/src/utils/notificationUtils.js
@@ -1,0 +1,35 @@
+export function requestNotificationPermission() {
+  if (!('Notification' in window)) {
+    return;
+  }
+  if (Notification.permission === 'default') {
+    Notification.requestPermission();
+  }
+}
+
+export function checkDueReminders(projects) {
+  if (!('Notification' in window)) {
+    return;
+  }
+  if (Notification.permission !== 'granted') {
+    return;
+  }
+
+  const notified = JSON.parse(localStorage.getItem('notifiedProjects') || '{}');
+  const now = new Date();
+
+  for (const project of projects) {
+    if (notified[project.id]) {
+      continue;
+    }
+    const dueDate = new Date(project.dueDate);
+    const diff = dueDate.getTime() - now.getTime();
+    if (diff > 0 && diff <= 24 * 60 * 60 * 1000) {
+      new Notification('Projekt bald fällig', {
+        body: `${project.title} ist in weniger als 24 Stunden fällig.`,
+      });
+      notified[project.id] = true;
+    }
+  }
+  localStorage.setItem('notifiedProjects', JSON.stringify(notified));
+}


### PR DESCRIPTION
## Summary
- allow the app to request notification permission and periodically check due dates
- show reminder notifications for projects due within 24h

## Testing
- `npm run lint` *(fails: couldn't find eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_68400c747848832e851eb59ccf6c7175